### PR TITLE
Define module as using bitcoin style encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 
-Fast base encoding / decoding of any given alphabet.
-
+Fast base encoding / decoding of any given alphabet using bitcoin style leading
+zero compression.
 
 ## Example
 
@@ -35,6 +35,38 @@ var bs62 = require('base-x')(BASE62)
 // ...
 ```
 
+## How it works
+
+It encodes octet arrays by doing long divisions on all significant digits in the
+array, creating a representation of that number in the new base. Then for every
+leading zero in the input (not significant as a number) it will encode as a
+single leader character. This is the first in the alphabet and will decode as 8
+bits. The other characters depend upon the base. For example, a base58 alphabet
+packs roughly 5.858 bits per character.
+
+This means the encoded string 000f (using a 0-f alphabet) will actually decode
+to 4 bytes unlike a typical hex codec which uniformly packs 4 bits into each
+character.
+
+While unusual, this does mean that no padding is required and it works for bases
+like 43. If you need standard hex encoding or base64 encoding you probably don't
+want this.
+
+The algorithm used to convert the base of the number is roughly this:
+
+```python
+significant =  12345
+base = 16
+digits = []
+while significant > base:
+  significant, remainder = divmod(significant, base)
+  digits.append(remainder)
+digits.append(significant)
+assert list(reversed(digits)) == [3,0,3,9]
+assert hex(12345) == '0x3039'
+```
+
+Of course the input is actually an array of digits already :)
 
 ## License
 

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -7,7 +7,13 @@
     {
       "alphabet": "base2",
       "hex": "00ff",
-      "string": "0000000011111111"
+      "comment" : "Note the first leading zero byte is compressed into 1 char",
+      "string": "011111111"
+    },
+    {
+      "alphabet": "base2",
+      "hex": "0fff",
+      "string": "111111111111"
     },
     {
       "alphabet": "base2",


### PR DESCRIPTION
This updates the broken base2 tests to pass, and adds fair warning what to expect.